### PR TITLE
Bug 549059 RAT triggered after disposing the context

### DIFF
--- a/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/internal/contexts/TrackableComputationExt.java
+++ b/bundles/org.eclipse.e4.core.contexts/src/org/eclipse/e4/core/internal/contexts/TrackableComputationExt.java
@@ -145,4 +145,7 @@ public class TrackableComputationExt extends Computation {
 		return null;
 	}
 
+	IEclipseContext getOriginatingContext() {
+		return originatingContext;
+	}
 }


### PR DESCRIPTION
Eclipse bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=549059

**Problem** 

When RAT handler code accesses the context's children, Eclipse automatically tracks this access by subscribing child contexts so the changes to the child context would also trigger the same RAT.

Normally, when the parent context is disposed, the child contexts also die along with all their listeners.

However, when a child context is reparented to another parent, the listener to the old parent remains forever - it stays there even after disposing the old parent context. Then a change in a child context may trigger a RAT handler is the disposed old parent.

**Fix** 

When a context changes its parent, we should iterate through all the tracked access listeners and check if the corresponding RAT's originating context is still in the context's new parent hierarchy. If it's no more the case, fix the leak by removing the listener.